### PR TITLE
Added comment to use --log-file option when using bu-isciii tools

### DIFF
--- a/docs/Assembly-service.md
+++ b/docs/Assembly-service.md
@@ -25,8 +25,10 @@ ll -tr
 Now, let's execute the first BU-ISCIII tool: `new-service`, where you'll need to specify the resolution ID associated to this service.
 
 ```shell
-bu-isciii new-service SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X
 ```
+
+The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. 
 
 Once `new-service` is executed, you'll be asked:
 
@@ -51,7 +53,7 @@ bash lablog_assembly
 After executing this file, if everything is OK, we can now proceed with the new BU-ISCIII tool: `scratch`. This tool will copy the content from `services_and_colaborations` to the `scratch_tmp` folder contained within `/data/bi`, since this `scratch_tmp` folder will be the one used for the assembly analysis.
 
 ```shell
-bu-isciii scratch SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.tool.log scratch SRVCNMXXX.X
 ```
 
 Once `scratch` is executed, you'll be asked:
@@ -118,7 +120,7 @@ multiqc_report.html     quast_global_report.html
 If everything is correct and all the files have the expected content, we can proceed to copy the content of the `RESULTS` folder to the researcher's SFTP. To do this, we should now execute the next BU-ISCIII tool: `finish`, which will delete temporary files, copy the results from scratch back to the `services_and_colaborations` folder, rename those folders that should not be copied into the researcher's SFTP and copy those that are of interest to this SFTP:
 
 ```shell
-bu-isciii finish SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.tool.log finish SRVCNMXXX.X
 ```
 
 After executing `finish`, you'll have to specify again that we are performing an assembly analysis (`assembly_annot`) and allow for this tools to rename (`RAW` and `TMP` will be renamed as `RAW_NC` and `TMP_NC`) and delete some folders (`work` will be deleted).
@@ -128,7 +130,7 @@ Once `finish` is done, the results will be now at the researcher's SFTP and we c
 To execute `bioinfo_doc`, we have to **go back to our WS user**, in which we should already have mounted the `bioinfo_doc` folder. If this is the case, we can do the following, **always after having checked the kmerfinder, quast and multiqc reports and looking for any remarkable aspects that the researcher should be informed about**:
 
 ```shell
-bu-isciii bioinfo-doc SRVCNMXXX.X > service_info
+bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X > service_info
 ```
 
 Once you've specified the `service_info` option, you should execute the `bioinfo-doc` BU-ISCIII tool again indicating the `delivery` option this time. Please note that the program will ask you to create the markdown files associated to this specific delivery, apart from whether we want to add some notes. If there is something we want to inform the researcher about, we can create a `delivery_notes.txt` with this information, by executing the following commands, **before executing `bu-isciii bioinfo-doc SRVCNMXXX.X > delivery`**:
@@ -143,7 +145,7 @@ Once this has been done, execute `bu-isciii bioinfo-doc SRVCNMXXX.X > delivery`,
 Lastly, remember to remove all the files related to this service from `scratch_tmp`:
 
 ```shell
-bu-isciii scratch SRVCNMXXX.X > remove_scratch
+bu-isciii --log-file SRVCNMXXX.X.tool.log scratch SRVCNMXXX.X > remove_scratch
 ```
 
 ## ASSEMBLY REPORT TEMPLATE (TEAM STANDUP)

--- a/docs/Assembly-service.md
+++ b/docs/Assembly-service.md
@@ -28,7 +28,7 @@ Now, let's execute the first BU-ISCIII tool: `new-service`, where you'll need to
 bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X
 ```
 
-The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. 
+The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. For instance, you may want to name the log as `SRVCNMXXX.X.new-service.log` if the function you are using is `new-service`. In other cases in which the tool has different options (i.e `scratch`, `bioinfo-doc`), you may want to use the name of the specific function you are about to use to save the log (i.e. `SRVCNMXXX.X.service_to_scratch.log` for tool `scratch` if you transfer data from service to scratch or `SRVCNMXXX.X.delivery.log` for `bioinfo-doc` if you are about to deliver the results).  
 
 Once `new-service` is executed, you'll be asked:
 
@@ -55,6 +55,8 @@ After executing this file, if everything is OK, we can now proceed with the new 
 ```shell
 bu-isciii --log-file SRVCNMXXX.X.tool.log scratch SRVCNMXXX.X
 ```
+
+Use the specific option you are using to name the log (i.e. `SRVCNMXXX.X.service_to_scratch.log`).
 
 Once `scratch` is executed, you'll be asked:
 
@@ -120,7 +122,7 @@ multiqc_report.html     quast_global_report.html
 If everything is correct and all the files have the expected content, we can proceed to copy the content of the `RESULTS` folder to the researcher's SFTP. To do this, we should now execute the next BU-ISCIII tool: `finish`, which will delete temporary files, copy the results from scratch back to the `services_and_colaborations` folder, rename those folders that should not be copied into the researcher's SFTP and copy those that are of interest to this SFTP:
 
 ```shell
-bu-isciii --log-file SRVCNMXXX.X.tool.log finish SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.finish.log finish SRVCNMXXX.X
 ```
 
 After executing `finish`, you'll have to specify again that we are performing an assembly analysis (`assembly_annot`) and allow for this tools to rename (`RAW` and `TMP` will be renamed as `RAW_NC` and `TMP_NC`) and delete some folders (`work` will be deleted).
@@ -132,6 +134,8 @@ To execute `bioinfo_doc`, we have to **go back to our WS user**, in which we sho
 ```shell
 bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X > service_info
 ```
+
+Remember to save the logs with the corresponding name (i.e. `SRVCNMXXX.X.service_info.log` or `SRVCNMXXX.X.delivery.log`).
 
 Once you've specified the `service_info` option, you should execute the `bioinfo-doc` BU-ISCIII tool again indicating the `delivery` option this time. Please note that the program will ask you to create the markdown files associated to this specific delivery, apart from whether we want to add some notes. If there is something we want to inform the researcher about, we can create a `delivery_notes.txt` with this information, by executing the following commands, **before executing `bu-isciii bioinfo-doc SRVCNMXXX.X > delivery`**:
 

--- a/docs/ExomeEB-ExomeTrio-WGSTrio-service.md
+++ b/docs/ExomeEB-ExomeTrio-WGSTrio-service.md
@@ -11,7 +11,7 @@ All these services use [Sarek](https://nf-co.re/sarek/3.4.0), a pipeline for Map
 
 ### 1. Create the service using [buisciii-tools](https://github.com/BU-ISCIII/buisciii-tools).
 
-- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVIIERXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. Type `N` to create the template folder and select the corresponding template folder (either exometrio, exomeeb or wgstrio).
+- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii --log-file SRVIIERXXX.X.tool.log new-service SRVIIERXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. FFor instance, you may want to name the log as `SRVIIERXXX.X.new-service.log` if the function you are using is `new-service`. In other cases in which the tool has different options (i.e `scratch`, `bioinfo-doc`), you may want to use the name of the specific function you are about to use to save the log (i.e. `SRVIIERXXX.X.service_to_scratch.log` for tool `scratch` if you transfer data from service to scratch or `SRVIIERXXX.X.delivery.log` for `bioinfo-doc` if you are about to deliver the results). Type `N` to create the template folder and select the corresponding template folder (either exometrio, exomeeb or wgstrio).
 - A folder will be created in `services_and_colaborations/CENTRE/SERVICE_TYPE` with the full name of the service, in the following format (YYYYMMDD = YearMonthDay):
 `SRVIIERXXX_YYYYMMDD_WGSTRIOXXX_researcheruser_S`
 - Go to the recently created folder. Check that the number of reading files matches the number of samples that was specified in the service in iSkyLIMS (the number of files must be number of samples x 2 if they are paired, since there is a file of forward readings and one of reverse readings)
@@ -22,7 +22,7 @@ ls -l *.fastq.gz | wc -l
 - For exome services, `REFERENCES` folder should include BED files with coordinates for the targeted regions, exons and/or genes during sequencing.
 - If everything is alright, move to `ANALYSIS` folder and execute `lablog` (This lablog might be named after the name of the template e.g. `lablog_exometrio`).
 - This first lablog will rename the main ANALYSIS folder (`DATE_ANALYSIS01`) to the current date and create folder `00-reads` with symlinks to the fastq files in `RAW`.
-- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVIIERXXX.X`.
+- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVIIERXXX.X.tool.log scratch --direction service_to_scratch SRVIIERXXX.X`. Use the specific option you are using to name the log (i.e. `SRVIIERXXX.X.service_to_scratch.log`).
 - From now on, all the analysis must be executed from the folder located in scratch.
 
 ### 2. Analysis starts: Sarek.

--- a/docs/ExomeEB-ExomeTrio-WGSTrio-service.md
+++ b/docs/ExomeEB-ExomeTrio-WGSTrio-service.md
@@ -11,7 +11,7 @@ All these services use [Sarek](https://nf-co.re/sarek/3.4.0), a pipeline for Map
 
 ### 1. Create the service using [buisciii-tools](https://github.com/BU-ISCIII/buisciii-tools).
 
-- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii new-service SRVIIERXXX.X`). Type `N` to create the template folder and select the corresponding template folder (either exometrio, exomeeb or wgstrio).
+- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVIIERXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. Type `N` to create the template folder and select the corresponding template folder (either exometrio, exomeeb or wgstrio).
 - A folder will be created in `services_and_colaborations/CENTRE/SERVICE_TYPE` with the full name of the service, in the following format (YYYYMMDD = YearMonthDay):
 `SRVIIERXXX_YYYYMMDD_WGSTRIOXXX_researcheruser_S`
 - Go to the recently created folder. Check that the number of reading files matches the number of samples that was specified in the service in iSkyLIMS (the number of files must be number of samples x 2 if they are paired, since there is a file of forward readings and one of reverse readings)
@@ -22,7 +22,7 @@ ls -l *.fastq.gz | wc -l
 - For exome services, `REFERENCES` folder should include BED files with coordinates for the targeted regions, exons and/or genes during sequencing.
 - If everything is alright, move to `ANALYSIS` folder and execute `lablog` (This lablog might be named after the name of the template e.g. `lablog_exometrio`).
 - This first lablog will rename the main ANALYSIS folder (`DATE_ANALYSIS01`) to the current date and create folder `00-reads` with symlinks to the fastq files in `RAW`.
-- Finally, move the folder to the computing resource using `bu-isciii scratch --direction service_to_scratch SRVIIERXXX.X`.
+- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVIIERXXX.X`.
 - From now on, all the analysis must be executed from the folder located in scratch.
 
 ### 2. Analysis starts: Sarek.

--- a/docs/IRMA-service.md
+++ b/docs/IRMA-service.md
@@ -7,7 +7,7 @@ This software does not include quality trimming of the raw reads by itself. Ther
 
 ### 0. Create the service using [buisciii-tools](https://github.com/BU-ISCIII/buisciii-tools).
 
-- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. Type `N` to create the template folder and select the corresponding template folder.
+- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. For instance, you may want to name the log as `SRVCNMXXX.X.new-service.log` if the function you are using is `new-service`. In other cases in which the tool has different options (i.e `scratch`, `bioinfo-doc`), you may want to use the name of the specific function you are about to use to save the log (i.e. `SRVCNMXXX.X.service_to_scratch.log` for tool `scratch` if you transfer data from service to scratch or `SRVCNMXXX.X.delivery.log` for `bioinfo-doc` if you are about to deliver the results). Type `N` to create the template folder and select the corresponding template folder.
 - A folder will be created in `services_and_colaborations/CENTRE/SERVICE_TYPE` with the full name of the service, in the following format (YYYYMMDD = YearMonthDay):
 `SRVCNMXXX_YYYYMMDD_GENOMEFLUXXX_researcheruser_S`
 - Go to the recently created folder. Check that the number of reading files matches the number of samples that was specified in the service in iSkyLIMS (the number of files must be number of samples x 2 if they are paired, since there is a file of forward readings and one of reverse readings)
@@ -18,7 +18,7 @@ ls -l *.fastq.gz | wc -l
 - If everything is alright, move to `ANALYSIS/` folder and execute `lablog` (This lablog might be named after the name of the template e.g. `lablog_irma`).
 - You will end up having two folders inside `ANALYSIS/`, one named `ANALYSIS01_FLU_IRMA` and `ANALYSIS02_MAG`
 - This first lablog will rename the ANALYSIS folders (`DATE_ANALYSIS01/02`) to the current date and create folder `00-reads` with symlinks to the fastq files in `RAW`.
-- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVCNMXXX.X`.
+- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVCNMXXX.X`. Use the specific option you are using to name the log (i.e. `SRVCNMXXX.X.service_to_scratch.log`).
 - From now on, all the analysis must be executed from the folder located in scratch.
 
 ### 1. Quality Control (FastQC)

--- a/docs/IRMA-service.md
+++ b/docs/IRMA-service.md
@@ -7,7 +7,7 @@ This software does not include quality trimming of the raw reads by itself. Ther
 
 ### 0. Create the service using [buisciii-tools](https://github.com/BU-ISCIII/buisciii-tools).
 
-- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii new-service SRVCNMXXX.X`). Type `N` to create the template folder and select the corresponding template folder.
+- Create the service from the local terminal using Iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. Type `N` to create the template folder and select the corresponding template folder.
 - A folder will be created in `services_and_colaborations/CENTRE/SERVICE_TYPE` with the full name of the service, in the following format (YYYYMMDD = YearMonthDay):
 `SRVCNMXXX_YYYYMMDD_GENOMEFLUXXX_researcheruser_S`
 - Go to the recently created folder. Check that the number of reading files matches the number of samples that was specified in the service in iSkyLIMS (the number of files must be number of samples x 2 if they are paired, since there is a file of forward readings and one of reverse readings)
@@ -18,7 +18,7 @@ ls -l *.fastq.gz | wc -l
 - If everything is alright, move to `ANALYSIS/` folder and execute `lablog` (This lablog might be named after the name of the template e.g. `lablog_irma`).
 - You will end up having two folders inside `ANALYSIS/`, one named `ANALYSIS01_FLU_IRMA` and `ANALYSIS02_MAG`
 - This first lablog will rename the ANALYSIS folders (`DATE_ANALYSIS01/02`) to the current date and create folder `00-reads` with symlinks to the fastq files in `RAW`.
-- Finally, move the folder to the computing resource using `bu-isciii scratch --direction service_to_scratch SRVCNMXXX.X`.
+- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVCNMXXX.X`.
 - From now on, all the analysis must be executed from the folder located in scratch.
 
 ### 1. Quality Control (FastQC)

--- a/docs/Viralrecon-service.md
+++ b/docs/Viralrecon-service.md
@@ -10,10 +10,10 @@ Load the buisciii-tools environment.
 
 Create the service and the needed folder structure. Select the **Viralrecon** template.
 
-    $ bu-isciii new-service SRVCNMXXX.X
+    $ bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X
     > Viralrecon
 
-> Note: If the resolution ID is not specified, it will be requested via the prompt.
+> Note: If the resolution ID is not specified, it will be requested via the prompt. The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service.
 
 If the service configuration is correct and the sequences are located in `/srv/fastq_repo`, move inside the newly created folder at `/data/bi/services_and_colaborations/CNM/virology/`. Check the `/RAW` folder to verify that symbolic links have been correctly created for all service samples.
 
@@ -29,7 +29,7 @@ Edit the folder name `YYMMDD_ANALYSIS_0X_MAG` based on the number of analyses to
 
 Copy the contents of the service folders to scratch. To do this, run the **scratch** tool from buisciii-tools.
 
-    $ bu-isciii scratch --direction service_to_scratch SRVCNMXXX.X
+    $ bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVCNMXXX.X
 
 Once finished, move to the newly copied service folder in scratch (its mounted path in scratch_tmp) `/data/bi/scratch_tmp/bi/`. Access the `ANALYSIS` folder and at this point, you will need to launch the pipeline once for each host successively. Access the folder of the first existing host (e.g., `YYYYMMDD_ANALYSIS01_METAGENOMIC_HUMAN`).
 
@@ -107,19 +107,19 @@ Access the newly created folder and execute the scripts in order.
 
 If everything is correct and the necessary files and links have been generated, you can proceed with the service completion. To do this, execute the finish module of buisciii-tools.
 
-    $ bu-isciii finish SRVCNMXXX.X
+    $ bu-isciii --log-file SRVCNMXXX.X.tool.log finish SRVCNMXXX.X
 
 This module will do several things. First, it cleans up the folder, removing all the folders and files than are not longer needed and take up a considerable amount of storage space. Then it copies all the service files back to its `/data/bi/services_and_colaborations/CNM/virology/` folder, and also copies the content of this service to the researcher's sftp repository.
 
 In order to complete the delivery of results to the researcher, you need to run the bioinfo-doc module of the buisciii-tools. To do so, you have to unlogin your HPC user and run it directly from your WS, where you have mounted the `/data/bioinfo_doc/` folder.
 
-    $ bu-isciii bioinfo-doc SRVCNMXXX.X
+    $ bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X
 
 This module will be executed twice. First time select the service_info option, and the next time select the delivery option. There is the option to add delivery notes (by prompt or by providing a file) during its execution.
 
 Lastly, remember to remove all the files related to this service from `scratch_tmp`:
 
-    $ bu-isciii scratch SRVCNMXXX.X
+    $ bu-isciii --log-file SRVCNMXXX.X.tool.log scratch SRVCNMXXX.X
     > remove_scratch
 
 ---

--- a/docs/Viralrecon-service.md
+++ b/docs/Viralrecon-service.md
@@ -13,7 +13,7 @@ Create the service and the needed folder structure. Select the **Viralrecon** te
     $ bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X
     > Viralrecon
 
-> Note: If the resolution ID is not specified, it will be requested via the prompt. The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service.
+> Note: If the resolution ID is not specified, it will be requested via the prompt. The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. For instance, you may want to name the log as `SRVCNMXXX.X.new-service.log` if the function you are using is `new-service`. In other cases in which the tool has different options (i.e `scratch`, `bioinfo-doc`), you may want to use the name of the specific function you are about to use to save the log (i.e. `SRVCNMXXX.X.service_to_scratch.log` for tool `scratch` if you transfer data from service to scratch or `SRVCNMXXX.X.delivery.log` for `bioinfo-doc` if you are about to deliver the results).
 
 If the service configuration is correct and the sequences are located in `/srv/fastq_repo`, move inside the newly created folder at `/data/bi/services_and_colaborations/CNM/virology/`. Check the `/RAW` folder to verify that symbolic links have been correctly created for all service samples.
 
@@ -30,6 +30,8 @@ Edit the folder name `YYMMDD_ANALYSIS_0X_MAG` based on the number of analyses to
 Copy the contents of the service folders to scratch. To do this, run the **scratch** tool from buisciii-tools.
 
     $ bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVCNMXXX.X
+
+Use the specific option you are using to name the log (i.e. `SRVCNMXXX.X.service_to_scratch.log`).
 
 Once finished, move to the newly copied service folder in scratch (its mounted path in scratch_tmp) `/data/bi/scratch_tmp/bi/`. Access the `ANALYSIS` folder and at this point, you will need to launch the pipeline once for each host successively. Access the folder of the first existing host (e.g., `YYYYMMDD_ANALYSIS01_METAGENOMIC_HUMAN`).
 
@@ -107,13 +109,15 @@ Access the newly created folder and execute the scripts in order.
 
 If everything is correct and the necessary files and links have been generated, you can proceed with the service completion. To do this, execute the finish module of buisciii-tools.
 
-    $ bu-isciii --log-file SRVCNMXXX.X.tool.log finish SRVCNMXXX.X
+    $ bu-isciii --log-file SRVCNMXXX.X.finish.log finish SRVCNMXXX.X
 
 This module will do several things. First, it cleans up the folder, removing all the folders and files than are not longer needed and take up a considerable amount of storage space. Then it copies all the service files back to its `/data/bi/services_and_colaborations/CNM/virology/` folder, and also copies the content of this service to the researcher's sftp repository.
 
 In order to complete the delivery of results to the researcher, you need to run the bioinfo-doc module of the buisciii-tools. To do so, you have to unlogin your HPC user and run it directly from your WS, where you have mounted the `/data/bioinfo_doc/` folder.
 
     $ bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X
+
+Remember to save the logs with the corresponding name (i.e. `SRVCNMXXX.X.service_info.log` or `SRVCNMXXX.X.delivery.log`).
 
 This module will be executed twice. First time select the service_info option, and the next time select the delivery option. There is the option to add delivery notes (by prompt or by providing a file) during its execution.
 

--- a/docs/mRNAseq-service.md
+++ b/docs/mRNAseq-service.md
@@ -32,8 +32,9 @@ If so, you are ready to proceed.
 
   - Copy files in the folder service from `services_and_colaborations` to `scratch_tmp/`.
     ```bash
-    bu-isciii scratch --direction service_to_scratch SRVXXXYYYY.1
+    bu-isciii --log-file SRVXXXYYYY.1.tool.log scratch --direction service_to_scratch SRVXXXYYYY.1
     ```
+    The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service.
 
 2. Go to `ANALYSIS/${DATE}_ANALYSIS01_RNASEQ` in the service folder copied to `scratch_tmp/` and execute the `lablog`.
   ```bash

--- a/docs/plasmidID-service.md
+++ b/docs/plasmidID-service.md
@@ -14,7 +14,7 @@ This service depends on `assembly` services as one of th plasmidID inputs is the
 
 ### 1. Create the service using [buisciii-tools](https://github.com/BU-ISCIII/buisciii-tools)
 
-- Create the service from the local terminal using iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. Type `Y` so the folder is not created (it's already created for the assembly step) and only the new plasmidid template is copied.
+- Create the service from the local terminal using iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. For instance, you may want to name the log as `SRVCNMXXX.X.new-service.log` if the function you are using is `new-service`. In other cases in which the tool has different options (i.e `scratch`, `bioinfo-doc`), you may want to use the name of the specific function you are about to use to save the log (i.e. `SRVCNMXXX.X.service_to_scratch.log` for tool `scratch` if you transfer data from service to scratch or `SRVCNMXXX.X.delivery.log` for `bioinfo-doc` if you are about to deliver the results). Type `Y` so the folder is not created (it's already created for the assembly step) and only the new plasmidid template is copied.
 - A folder will be created in `services_and_colaborations/CENTRE/SERVICE_TYPE` with the full name of the service.
 - Go to the recently created folder. Check that the number of reading files matches the number of samples that was specified in the service in iSkyLIMS (the number of files must be number of samples x 2 if they are paired, since there is a file of forward readings and one of reverse readings)
 
@@ -25,7 +25,7 @@ ls -l *.fastq.gz | wc -l
 
 - If everything is alright, move to `ANALYSIS` folder and execute `lablog` (This lablog might be named after the name of the template e.g. `lablog_plasmidid`).
 - This first lablog will rename the main ANALYSIS folder (`DATE_ANALYSIS01`) to the current date and create folder `00-reads` with symlinks to the fastq files in `RAW`.
-- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVIIERXXX.X`.
+- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVCNMXXX.X`. Use the specific option you are using to name the log (i.e. `SRVCNMXXX.X.service_to_scratch.log`).
 - From now on, all the analysis must be executed from the folder located in scratch.
 
 ### 2. Analysis starts
@@ -56,17 +56,18 @@ Always check that the files are correctly copied/proper links created to the del
 If everything is correct and all the files have the expected content, we can proceed with the bu-isciii tools finish module:
 
 ```Bash
-bu-isciii --log-file SRVCNMXXX.X.tool.log finish SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.finish.log finish SRVCNMXXX.X
 ```
 
 Once someone has reviewed the service and given the ok, you can deliver the service. Remember to move to your workstation for this:
 
 ```Bash
-bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.service-info.log bioinfo-doc SRVCNMXXX.X
 # select service-info
-bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.delivery.log bioinfo-doc SRVCNMXXX.X
 # select delivery
 ```
+
 
 ### mRNAseq report template (TEAM STANDUP)
 

--- a/docs/plasmidID-service.md
+++ b/docs/plasmidID-service.md
@@ -14,7 +14,7 @@ This service depends on `assembly` services as one of th plasmidID inputs is the
 
 ### 1. Create the service using [buisciii-tools](https://github.com/BU-ISCIII/buisciii-tools)
 
-- Create the service from the local terminal using iskylims Resolution ID (e.g. `bu-isciii new-service SRVCNMXXX.X`). Type `Y` so the folder is not created (it's already created for the assembly step) and only the new plasmidid template is copied.
+- Create the service from the local terminal using iskylims Resolution ID (e.g. `bu-isciii --log-file SRVCNMXXX.X.tool.log new-service SRVCNMXXX.X`). The option `--log-file` will save a log for tracking purposes in a specific location. This option should be used every time the BU-ISCIII tool is used for the service. Type `Y` so the folder is not created (it's already created for the assembly step) and only the new plasmidid template is copied.
 - A folder will be created in `services_and_colaborations/CENTRE/SERVICE_TYPE` with the full name of the service.
 - Go to the recently created folder. Check that the number of reading files matches the number of samples that was specified in the service in iSkyLIMS (the number of files must be number of samples x 2 if they are paired, since there is a file of forward readings and one of reverse readings)
 
@@ -25,7 +25,7 @@ ls -l *.fastq.gz | wc -l
 
 - If everything is alright, move to `ANALYSIS` folder and execute `lablog` (This lablog might be named after the name of the template e.g. `lablog_plasmidid`).
 - This first lablog will rename the main ANALYSIS folder (`DATE_ANALYSIS01`) to the current date and create folder `00-reads` with symlinks to the fastq files in `RAW`.
-- Finally, move the folder to the computing resource using `bu-isciii scratch --direction service_to_scratch SRVIIERXXX.X`.
+- Finally, move the folder to the computing resource using `bu-isciii --log-file SRVCNMXXX.X.tool.log scratch --direction service_to_scratch SRVIIERXXX.X`.
 - From now on, all the analysis must be executed from the folder located in scratch.
 
 ### 2. Analysis starts
@@ -56,15 +56,15 @@ Always check that the files are correctly copied/proper links created to the del
 If everything is correct and all the files have the expected content, we can proceed with the bu-isciii tools finish module:
 
 ```Bash
-bu-isciii finish SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.tool.log finish SRVCNMXXX.X
 ```
 
 Once someone has reviewed the service and given the ok, you can deliver the service. Remember to move to your workstation for this:
 
 ```Bash
-bu-isciii bioinfo-doc SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X
 # select service-info
-bu-isciii bioinfo-doc SRVCNMXXX.X
+bu-isciii --log-file SRVCNMXXX.X.tool.log bioinfo-doc SRVCNMXXX.X
 # select delivery
 ```
 


### PR DESCRIPTION
Comments about `--log-file` option have been added in certain manuals used for service as a reminder of its use for tracking purpose. 
A potential nomenclature has also been added for the file name used to save the log (SRVCNMXXX.X.tool.log).