### PR TITLE
Fixed path when mounting bioinfo_doc by removing ucct

### DIFF
--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -94,7 +94,7 @@ sudo sshfs -o reconnect,ServerAliveInterval=15,ServerAliveCountMax=3,allow_other
 ```
 3. Now, mount `/data/ucct/bioinfo_doc/` in your WS
 ```
-sudo mount -t cifs -o username=<user>,domain=ISCIII,uid=XXXX,gid=XXXX //neptuno.isciii.es/bioinfo_doc /data/ucct/bioinfo_doc
+sudo mount -t cifs -o username=<user>,domain=ISCIII,uid=XXXX,gid=XXXX //neptuno.isciii.es/bioinfo_doc /data/bioinfo_doc
 ```
 
 >[!NOTE]


### PR DESCRIPTION
Removed '_ucct_' from the path in FAQs to ensure bioinfo_doc is mounted at `/data/bioinfo_doc` locally, as required by buisciii tools for `service_info`.